### PR TITLE
Use config in commented code

### DIFF
--- a/precipitation-irrigation.js
+++ b/precipitation-irrigation.js
@@ -53,7 +53,7 @@ function decideIfToIrrigate(RainValue) {
     if (RainValue > CONFIG.rainMmValue) {
 //        Can be use to caluculate irrigration time base of amount the Rain last 24h
 //        let seconds_to_irrigate = (10 - RainValue) * 30;
-//        Shelly.call("Switch.Set", {"id": 0, "on": true, "toggle_after": seconds_to_irrigate});
+//        Shelly.call("Switch.Set", {"id": CONFIG.switchId, "on": true, "toggle_after": seconds_to_irrigate});
         Shelly.call("Switch.Set", {"id": CONFIG.switchId, "on": false}); // Disable if you calculate irrigration time
         print("Irrigration not needed");
     }


### PR DESCRIPTION
Obviously has no actual effect since the code is commented out but it serves as an example and should use the config.

