### PR TITLE
Fix: Universal-blu-to-mqtt decode incomplete problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Initial support for Shelly Script comes with firmware version 0.9, September
 2021 for Gen2 Shellies based on ESP32.
 
 # Changelog
+## 2024-12
+- Update some legacy code to the latest version.
 ## 2024-11
 - Add a universal BLU to MQTT script
 - Fixed n-way-dimmer synchronization problem

--- a/ble-shelly-blu.js
+++ b/ble-shelly-blu.js
@@ -145,7 +145,7 @@ const BTHomeDecoder = {
       else {
         if (Array.isArray(result[_bth.n])) {
           result[_bth.n].push(_value);
-        } 
+        }
         else {
           result[_bth.n] = [
             result[_bth.n],
@@ -244,11 +244,11 @@ function init() {
   else {
     //start the scanner
     const bleScanner = BLE.Scanner.Start({
-        duration_ms: BLE.Scanner.INFINITE_SCAN,
-        active: CONFIG.active
+      duration_ms: BLE.Scanner.INFINITE_SCAN,
+      active: CONFIG.active
     });
 
-    if(!bleScanner) {
+    if (!bleScanner) {
       console.log("Error: Can not start new scanner");
     }
   }
@@ -258,7 +258,7 @@ function init() {
 
   // disable console.log when logs are disabled
   if (!CONFIG.debug) {
-    console.log = function() {};
+    console.log = function () { };
   }
 }
 

--- a/ble-shelly-btn-gateway-for-other-devices.js
+++ b/ble-shelly-btn-gateway-for-other-devices.js
@@ -18,7 +18,7 @@
 
 
 /** =============================== CHANGE HERE =============================== */
-let CONFIG = {
+const CONFIG = {
     bluButtonAddress: "b4:35:22:fe:56:e5", //the mac address of shelly blu button1 that will trigger the actions
     actions: { //urls to be called on a event
         //when adding urls you must separate them with commas and put them in quotation marks
@@ -44,28 +44,34 @@ let CONFIG = {
 };
 /** =============================== STOP CHANGING HERE =============================== */
 
-let urlsPerCall = 3; 
+let urlsPerCall = 3;
 let urlsQueue = [];
 let callsCounter = 0;
 
-let ALLTERCO_MFD_ID_STR = "0ba9";
-let BTHOME_SVC_ID_STR = "fcd2";
+const ALLTERCO_MFD_ID_STR = "0ba9";
+const BTHOME_SVC_ID_STR = "fcd2";
 
-let uint8 = 0;
-let int8 = 1;
-let uint16 = 2;
-let int16 = 3;
-let uint24 = 4;
-let int24 = 5;
+const uint8 = 0;
+const int8 = 1;
+const uint16 = 2;
+const int16 = 3;
+const uint24 = 4;
+const int24 = 5;
 
-let BTH = {};
-BTH[0x00] = { n: "pid", t: uint8 };
-BTH[0x01] = { n: "Battery", t: uint8, u: "%" };
-BTH[0x05] = { n: "Illuminance", t: uint24, f: 0.01 };
-BTH[0x1a] = { n: "Door", t: uint8 };
-BTH[0x20] = { n: "Moisture", t: uint8 };
-BTH[0x2d] = { n: "Window", t: uint8 };
-BTH[0x3a] = { n: "Button", t: uint8 };
+// The BTH object defines the structure of the BTHome data
+const BTH = {
+    0x00: { n: "pid", t: uint8 },
+    0x01: { n: "battery", t: uint8, u: "%" },
+    0x02: { n: "temperature", t: int16, f: 0.01, u: "tC" },
+    0x03: { n: "humidity", t: uint16, f: 0.01, u: "%" },
+    0x05: { n: "illuminance", t: uint24, f: 0.01 },
+    0x21: { n: "motion", t: uint8 },
+    0x2d: { n: "window", t: uint8 },
+    0x2e: { n: "humidity", t: uint8, u: "%" },
+    0x3a: { n: "button", t: uint8 },
+    0x3f: { n: "rotation", t: int16, f: 0.1 },
+    0x45: { n: "temperature", t: int16, f: 0.1, u: "tC" },
+};
 
 function getByteSize(type) {
     if (type === uint8 || type === int8) return 1;
@@ -75,9 +81,10 @@ function getByteSize(type) {
     return 255;
 }
 
-let BTHomeDecoder = {
+// functions for decoding and unpacking the service data from Shelly BLU devices
+const BTHomeDecoder = {
     utoi: function (num, bitsz) {
-        let mask = 1 << (bitsz - 1);
+        const mask = 1 << (bitsz - 1);
         return num & mask ? num - (1 << bitsz) : num;
     },
     getUInt8: function (buffer) {
@@ -111,6 +118,8 @@ let BTHomeDecoder = {
         if (type === int24) res = this.getInt24LE(buffer);
         return res;
     },
+
+    // Unpacks the service data buffer from a Shelly BLU device
     unpack: function (buffer) {
         //beacons might not provide BTH service data
         if (typeof buffer !== "string" || buffer.length === 0) return null;
@@ -128,14 +137,29 @@ let BTHomeDecoder = {
         while (buffer.length > 0) {
             _bth = BTH[buffer.at(0)];
             if (typeof _bth === "undefined") {
-                console.log("BTH: unknown type");
+                console.log("BTH: Unknown type");
                 break;
             }
             buffer = buffer.slice(1);
             _value = this.getBufValue(_bth.t, buffer);
             if (_value === null) break;
             if (typeof _bth.f !== "undefined") _value = _value * _bth.f;
-            result[_bth.n] = _value;
+
+            if (typeof result[_bth.n] === "undefined") {
+                result[_bth.n] = _value;
+            }
+            else {
+                if (Array.isArray(result[_bth.n])) {
+                    result[_bth.n].push(_value);
+                }
+                else {
+                    result[_bth.n] = [
+                        result[_bth.n],
+                        _value
+                    ];
+                }
+            }
+
             buffer = buffer.slice(getByteSize(_bth.t));
         }
         return result;
@@ -143,35 +167,31 @@ let BTHomeDecoder = {
 };
 
 function callQueue() {
-    if(callsCounter < 6 - urlsPerCall) {
-        for(let i = 0; i < urlsPerCall && i < urlsQueue.length; i++) {
+    if (callsCounter < 6 - urlsPerCall) {
+        for (let i = 0; i < urlsPerCall && i < urlsQueue.length; i++) {
             let url = urlsQueue.splice(0, 1)[0];
             callsCounter++;
-            Shelly.call("HTTP.GET", { 
-                url: url, 
+            Shelly.call("HTTP.GET", {
+                url: url,
                 timeout: 5
-                }, 
-                function(_, error_code, _, data) {
-                    if(error_code !== 0) {
+            },
+                function (_, error_code, _, data) {
+                    if (error_code !== 0) {
                         console.log("Calling", data.url, "failed");
                     }
-                    else {
-                        console.log("Calling", data.url, "successed");
-                    }
-
                     callsCounter--;
-                }, 
+                },
                 { url: url }
             );
         }
     }
 
     //if there are more urls in the queue
-    if(urlsQueue.length > 0) {
+    if (urlsQueue.length > 0) {
         Timer.set(
             1000, //the delay
-            false, 
-            function() {
+            false,
+            function () {
                 callQueue();
             }
         );
@@ -186,10 +206,10 @@ function bleScanCallback(event, result) {
     }
 
     //exit if the data is not coming from a Shelly Blu button1 and if the mac address doesn't match
-    if (    typeof result.local_name === "undefined" || 
-            typeof result.addr === "undefined" || 
-            result.local_name.indexOf("SBBT") !== 0 || 
-            result.addr !== CONFIG.bluButtonAddress
+    if (typeof result.local_name === "undefined" ||
+        typeof result.addr === "undefined" ||
+        result.local_name.indexOf("SBBT") !== 0 ||
+        result.addr !== CONFIG.bluButtonAddress
     ) {
         return;
     }
@@ -197,7 +217,7 @@ function bleScanCallback(event, result) {
     let servData = result.service_data;
 
     //exit if service data is null/device is encrypted
-    if(servData === null || typeof servData === "undefined" || typeof servData[BTHOME_SVC_ID_STR] === "undefined") {
+    if (servData === null || typeof servData === "undefined" || typeof servData[BTHOME_SVC_ID_STR] === "undefined") {
         console.log("Can't handle encrypted devices");
         return;
     }
@@ -205,7 +225,7 @@ function bleScanCallback(event, result) {
     let receivedData = BTHomeDecoder.unpack(servData[BTHOME_SVC_ID_STR]);
 
     //exit if unpacked data is null or the device is encrypted
-    if(receivedData === null || typeof receivedData === "undefined" || receivedData["encryption"]) {
+    if (receivedData === null || typeof receivedData === "undefined" || receivedData["encryption"]) {
         console.log("Can't handle encrypted devices");
         return;
     }
@@ -223,13 +243,13 @@ function bleScanCallback(event, result) {
     let actionUrls = CONFIG.actions[actionType];
 
     //exit if the event doesn't exist in the config    
-    if(typeof actionType === "undefined") {
+    if (typeof actionType === "undefined") {
         console.log("Unknown event type in the config");
         return;
     }
 
     //save all urls into the queue for the current event
-    for(let i in actionUrls) {
+    for (let i in actionUrls) {
         urlsQueue.push(actionUrls[i]);
     }
 
@@ -241,7 +261,7 @@ function bleScan() {
     let bleConfig = Shelly.getComponentConfig("ble");
 
     //exit if the bluetooth is not enabled
-    if(bleConfig.enable === false) {
+    if (bleConfig.enable === false) {
         console.log("BLE is not enabled");
         return;
     }
@@ -253,7 +273,7 @@ function bleScan() {
     });
 
     //exist if the scanner can not be started
-    if(bleScanner === false) {
+    if (bleScanner === false) {
         console.log("Error when starting the BLE scanner");
         return;
     }
@@ -264,19 +284,19 @@ function bleScan() {
 
 function init() {
     //exit if there isn't a config
-    if(typeof CONFIG === "undefined") {
+    if (typeof CONFIG === "undefined") {
         console.log("Can't read the config");
         return;
     }
 
     //exit if there isn't a blu button address
-    if(typeof CONFIG.bluButtonAddress !== "string") {
+    if (typeof CONFIG.bluButtonAddress !== "string") {
         console.log("Error with the Shelly BLU button1's address");
         return;
     }
-    
+
     //exit if there isn't action object
-    if(typeof CONFIG.actions === "undefined") {
+    if (typeof CONFIG.actions === "undefined") {
         console.log("Can't find the actions object in the config");
         return;
     }

--- a/ble-shelly-btn.js
+++ b/ble-shelly-btn.js
@@ -75,20 +75,30 @@ let CONFIG = {
 };
 // END OF CHANGE
 
-let ALLTERCO_MFD_ID_STR = "0ba9";
-let BTHOME_SVC_ID_STR = "fcd2";
+const ALLTERCO_MFD_ID_STR = "0ba9";
+const BTHOME_SVC_ID_STR = "fcd2";
 
-let SCAN_DURATION = BLE.Scanner.INFINITE_SCAN;
-let ACTIVE_SCAN =
-  typeof CONFIG.shelly_blu_name_prefix !== "undefined" &&
-  CONFIG.shelly_blu_name_prefix !== null;
+const uint8 = 0;
+const int8 = 1;
+const uint16 = 2;
+const int16 = 3;
+const uint24 = 4;
+const int24 = 5;
 
-let uint8 = 0;
-let int8 = 1;
-let uint16 = 2;
-let int16 = 3;
-let uint24 = 4;
-let int24 = 5;
+// The BTH object defines the structure of the BTHome data
+const BTH = {
+  0x00: { n: "pid", t: uint8 },
+  0x01: { n: "battery", t: uint8, u: "%" },
+  0x02: { n: "temperature", t: int16, f: 0.01, u: "tC" },
+  0x03: { n: "humidity", t: uint16, f: 0.01, u: "%" },
+  0x05: { n: "illuminance", t: uint24, f: 0.01 },
+  0x21: { n: "motion", t: uint8 },
+  0x2d: { n: "window", t: uint8 },
+  0x2e: { n: "humidity", t: uint8, u: "%" },
+  0x3a: { n: "button", t: uint8 },
+  0x3f: { n: "rotation", t: int16, f: 0.1 },
+  0x45: { n: "temperature", t: int16, f: 0.1, u: "tC" },
+};
 
 function getByteSize(type) {
   if (type === uint8 || type === int8) return 1;
@@ -98,19 +108,10 @@ function getByteSize(type) {
   return 255;
 }
 
-let BTH = [];
-BTH[0x00] = { n: "pid", t: uint8 };
-BTH[0x01] = { n: "Battery", t: uint8, u: "%" };
-BTH[0x05] = { n: "Illuminance", t: uint24, f: 0.01 };
-BTH[0x1a] = { n: "Door", t: uint8 };
-BTH[0x20] = { n: "Moisture", t: uint8 };
-BTH[0x2d] = { n: "Window", t: uint8 };
-BTH[0x3a] = { n: "Button", t: uint8 };
-BTH[0x3f] = { n: "Rotation", t: int16, f: 0.1 };
-
-let BTHomeDecoder = {
+// functions for decoding and unpacking the service data from Shelly BLU devices
+const BTHomeDecoder = {
   utoi: function (num, bitsz) {
-    let mask = 1 << (bitsz - 1);
+    const mask = 1 << (bitsz - 1);
     return num & mask ? num - (1 << bitsz) : num;
   },
   getUInt8: function (buffer) {
@@ -144,15 +145,17 @@ let BTHomeDecoder = {
     if (type === int24) res = this.getInt24LE(buffer);
     return res;
   },
+
+  // Unpacks the service data buffer from a Shelly BLU device
   unpack: function (buffer) {
-    // beacons might not provide BTH service data
+    //beacons might not provide BTH service data
     if (typeof buffer !== "string" || buffer.length === 0) return null;
     let result = {};
     let _dib = buffer.at(0);
     result["encryption"] = _dib & 0x1 ? true : false;
     result["BTHome_version"] = _dib >> 5;
     if (result["BTHome_version"] !== 2) return null;
-    //Can not handle encrypted data
+    //can not handle encrypted data
     if (result["encryption"]) return result;
     buffer = buffer.slice(1);
 
@@ -161,14 +164,29 @@ let BTHomeDecoder = {
     while (buffer.length > 0) {
       _bth = BTH[buffer.at(0)];
       if (typeof _bth === "undefined") {
-        console.log("BTH: unknown type");
+        console.log("BTH: Unknown type");
         break;
       }
       buffer = buffer.slice(1);
       _value = this.getBufValue(_bth.t, buffer);
       if (_value === null) break;
       if (typeof _bth.f !== "undefined") _value = _value * _bth.f;
-      result[_bth.n] = _value;
+
+      if (typeof result[_bth.n] === "undefined") {
+        result[_bth.n] = _value;
+      }
+      else {
+        if (Array.isArray(result[_bth.n])) {
+          result[_bth.n].push(_value);
+        }
+        else {
+          result[_bth.n] = [
+            result[_bth.n],
+            _value
+          ];
+        }
+      }
+
       buffer = buffer.slice(getByteSize(_bth.t));
     }
     return result;
@@ -237,7 +255,7 @@ function scanCB(ev, res) {
 // BLE infrastructure was up in the Shelly
 function startBLEScan() {
   let bleScanSuccess = BLE.Scanner.Start({ duration_ms: SCAN_DURATION, active: ACTIVE_SCAN }, scanCB);
-  if( bleScanSuccess === false ) {
+  if (bleScanSuccess === false) {
     Timer.set(1000, false, startBLEScan);
   } else {
     console.log('Success: BLU button scanner running');
@@ -246,7 +264,7 @@ function startBLEScan() {
 
 //Check for BLE config and print a message if BLE is not enabled on the device
 let BLEConfig = Shelly.getComponentConfig('ble');
-if(BLEConfig.enable === false) {
+if (BLEConfig.enable === false) {
   console.log('Error: BLE not enabled');
 } else {
   Timer.set(1000, false, startBLEScan);

--- a/ble-shelly-dw.js
+++ b/ble-shelly-dw.js
@@ -70,23 +70,30 @@ let CONFIG = {
 };
 // END OF CHANGE
 
-let ALLTERCO_MFD_ID_STR = "0ba9";
-let BTHOME_SVC_ID_STR = "fcd2";
+const ALLTERCO_MFD_ID_STR = "0ba9";
+const BTHOME_SVC_ID_STR = "fcd2";
 
-let ALLTERCO_MFD_ID = JSON.parse("0x" + ALLTERCO_MFD_ID_STR);
-let BTHOME_SVC_ID = JSON.parse("0x" + BTHOME_SVC_ID_STR);
+const uint8 = 0;
+const int8 = 1;
+const uint16 = 2;
+const int16 = 3;
+const uint24 = 4;
+const int24 = 5;
 
-let SCAN_DURATION = BLE.Scanner.INFINITE_SCAN;
-let ACTIVE_SCAN =
-  typeof CONFIG.shelly_blu_name_prefix !== "undefined" &&
-  CONFIG.shelly_blu_name_prefix !== null;
-
-let uint8 = 0;
-let int8 = 1;
-let uint16 = 2;
-let int16 = 3;
-let uint24 = 4;
-let int24 = 5;
+// The BTH object defines the structure of the BTHome data
+const BTH = {
+  0x00: { n: "pid", t: uint8 },
+  0x01: { n: "battery", t: uint8, u: "%" },
+  0x02: { n: "temperature", t: int16, f: 0.01, u: "tC" },
+  0x03: { n: "humidity", t: uint16, f: 0.01, u: "%" },
+  0x05: { n: "illuminance", t: uint24, f: 0.01 },
+  0x21: { n: "motion", t: uint8 },
+  0x2d: { n: "window", t: uint8 },
+  0x2e: { n: "humidity", t: uint8, u: "%" },
+  0x3a: { n: "button", t: uint8 },
+  0x3f: { n: "rotation", t: int16, f: 0.1 },
+  0x45: { n: "temperature", t: int16, f: 0.1, u: "tC" },
+};
 
 function getByteSize(type) {
   if (type === uint8 || type === int8) return 1;
@@ -96,19 +103,10 @@ function getByteSize(type) {
   return 255;
 }
 
-let BTH = [];
-BTH[0x00] = { n: "pid", t: uint8 };
-BTH[0x01] = { n: "Battery", t: uint8, u: "%" };
-BTH[0x05] = { n: "Illuminance", t: uint24, f: 0.01 };
-BTH[0x1a] = { n: "Door", t: uint8 };
-BTH[0x20] = { n: "Moisture", t: uint8 };
-BTH[0x2d] = { n: "Window", t: uint8 };
-BTH[0x3a] = { n: "Button", t: uint8 };
-BTH[0x3f] = { n: "Rotation", t: int16, f: 0.1 };
-
-let BTHomeDecoder = {
+// functions for decoding and unpacking the service data from Shelly BLU devices
+const BTHomeDecoder = {
   utoi: function (num, bitsz) {
-    let mask = 1 << (bitsz - 1);
+    const mask = 1 << (bitsz - 1);
     return num & mask ? num - (1 << bitsz) : num;
   },
   getUInt8: function (buffer) {
@@ -142,15 +140,17 @@ let BTHomeDecoder = {
     if (type === int24) res = this.getInt24LE(buffer);
     return res;
   },
+
+  // Unpacks the service data buffer from a Shelly BLU device
   unpack: function (buffer) {
-    // beacons might not provide BTH service data
+    //beacons might not provide BTH service data
     if (typeof buffer !== "string" || buffer.length === 0) return null;
     let result = {};
     let _dib = buffer.at(0);
     result["encryption"] = _dib & 0x1 ? true : false;
     result["BTHome_version"] = _dib >> 5;
     if (result["BTHome_version"] !== 2) return null;
-    //Can not handle encrypted data
+    //can not handle encrypted data
     if (result["encryption"]) return result;
     buffer = buffer.slice(1);
 
@@ -158,15 +158,30 @@ let BTHomeDecoder = {
     let _value;
     while (buffer.length > 0) {
       _bth = BTH[buffer.at(0)];
-      if (_bth === "undefined") {
-        console.log("BTH: unknown type");
+      if (typeof _bth === "undefined") {
+        console.log("BTH: Unknown type");
         break;
       }
       buffer = buffer.slice(1);
       _value = this.getBufValue(_bth.t, buffer);
       if (_value === null) break;
       if (typeof _bth.f !== "undefined") _value = _value * _bth.f;
-      result[_bth.n] = _value;
+
+      if (typeof result[_bth.n] === "undefined") {
+        result[_bth.n] = _value;
+      }
+      else {
+        if (Array.isArray(result[_bth.n])) {
+          result[_bth.n].push(_value);
+        }
+        else {
+          result[_bth.n] = [
+            result[_bth.n],
+            _value
+          ];
+        }
+      }
+
       buffer = buffer.slice(getByteSize(_bth.t));
     }
     return result;

--- a/howto/input-read.js
+++ b/howto/input-read.js
@@ -1,21 +1,14 @@
-Shelly.call(
-  "input.getstatus",
-  {
-    //for more than one input devices use the respective id
-    id: 0,
-  },
-  function (result, error_code, error_message) {
-    print(JSON.stringify(result));
-    //result
-    // {
-    //     "state": false,
-    //     "id": 0
-    // }
+const result = Shelly.getComponentStatus("Input:0");
 
-    //if we need to check the state of the input
-    //peek into result.state
-    if (result.state === true) {
-      print("Input is on");
-    }
-  }
-);
+print(JSON.stringify(result));
+//result
+// {
+//     "state": false,
+//     "id": 0
+// }
+
+//if we need to check the state of the input
+//peek into result.state
+if (result.state === true) {
+  print("Input is on");
+}

--- a/howto/switch-read.js
+++ b/howto/switch-read.js
@@ -14,18 +14,11 @@
 //     "id": 0
 // }
 
-Shelly.call(
-  "switch.getstatus",
-  {
-    //for more than one switch devices use the respective id
-    id: 0,
-  },
-  function (result, error_code, error_message) {
-    print(JSON.stringify(result));
-    //if we need to check the state of the switch
-    //peek into result.output
-    if (result.output === true) {
-      print("Switch is on");
-    }
-  }
-);
+const result = Shelly.getComponentStatus("Switch:0");
+
+print(JSON.stringify(result));
+//if we need to check the state of the switch
+//peek into result.output
+if (result.output === true) {
+  print("Switch is on");
+}

--- a/mqtt-announce.js
+++ b/mqtt-announce.js
@@ -17,16 +17,7 @@
 // Shelly Script example: Use MQTT in scripting to provide backwards compatibility
 // with Gen1 MQTT topics shellies/announce and shellies/command
 
-let deviceInfo = null;
-
-Shelly.call(
-  "Shelly.GetDeviceInfo",
-  {},
-  function (result, error_code, error_message) {
-    if (error_code) return;
-    deviceInfo = result;
-  }
-);
+const deviceInfo = Shelly.getDeviceInfo();
 
 MQTT.subscribe(
   "shellies/command",

--- a/mqtt-discovery.js
+++ b/mqtt-discovery.js
@@ -33,10 +33,12 @@
  * @typedef {"config"|"stat"|"cmd"} HATopicType
  */
 
-let CONFIG = {
-  shelly_id: null,
-  shelly_mac: null,
-  shelly_fw_id: null,
+
+const deviceInfo = Shelly.getDeviceInfo();
+const CONFIG = {
+  shelly_id: deviceInfo.id,
+  shelly_mac: deviceInfo.mac,
+  shelly_fw_id: deviceInfo.fw_id,
   ha_mqtt_ad: "garage_homeassistant",
   device_name: "VIRTUAL_SWITCH",
   payloads: {
@@ -45,12 +47,7 @@ let CONFIG = {
   },
 };
 
-Shelly.call("Shelly.GetDeviceInfo", {}, function (result) {
-  CONFIG.shelly_id = result.id;
-  CONFIG.shelly_mac = result.mac;
-  CONFIG.shelly_fw_id = result.fw_id;
-  initMQTT();
-});
+initMQTT();
 
 /**
  * @param   {HADeviceType}   hatype HA device type

--- a/mqtt-switch-status-announce.js
+++ b/mqtt-switch-status-announce.js
@@ -1,33 +1,25 @@
-let CONFIG = {
+
+const mqttConfig = Shelly.getComponentConfig("MQTT"); // Get mqtt config
+
+const CONFIG = {
   switchId: 0,
   interval: 40000,
   MQTTPublishTopic: "/status/switch:",
 };
 
-let SHELLY_ID = undefined;
-
-Shelly.call("Mqtt.GetConfig", "", function (res, err_code, err_msg, ud) {
-  SHELLY_ID = res["topic_prefix"];
-});
+const SHELLY_ID = mqttConfig.topic_prefix;
 
 let notifyTimer = Timer.set(CONFIG.interval, true, function () {
-  Shelly.call(
-    "Switch.GetStatus",
-    {
-      id: CONFIG.switchId,
-    },
-    function (res, err_code, err_msg, ud) {
-      if (typeof SHELLY_ID === "undefined") {
-        return;
-      }
-      if (typeof res !== "undefined" || res !== null) {
-        MQTT.publish(
-          SHELLY_ID + CONFIG.MQTTPublishTopic + JSON.stringify(CONFIG.switchId),
-          JSON.stringify(res),
-          0,
-          false
-        );
-      }
-    }
-  );
+  const res = Shelly.getComponentStatus("Switch:" + CONFIG.switchId)
+  if (typeof SHELLY_ID === "undefined") {
+    return;
+  }
+  if (typeof res !== "undefined" || res !== null) {
+    MQTT.publish(
+      SHELLY_ID + CONFIG.MQTTPublishTopic + JSON.stringify(CONFIG.switchId),
+      JSON.stringify(res),
+      0,
+      false
+    );
+  }
 });

--- a/n-way-dimmer.js
+++ b/n-way-dimmer.js
@@ -29,12 +29,10 @@ const KVS_KEY = "nwayOn"; // unify KVS key
 
 // get local IP
 function setWifiIP() {
-  Shelly.call("WiFi.GetStatus", null, function (status) {
-    console.log("Saving Wifi IP: ", status.sta_ip)
-    if (status.status === "got ip") {
-      CONFIG.wifiIP = status.sta_ip;
-    }
-  });
+  const wifiStatus = Shelly.getComponentStatus("Wifi");
+  if (wifiStatus.status === "got ip") {
+    CONFIG.wifiIP = wifiStatus.sta_ip;
+  }
 }
 
 //  You should not need to modify anything past here

--- a/restore-schedule.js
+++ b/restore-schedule.js
@@ -3,12 +3,15 @@
 // and will ensure that the scheduled task that was to be run
 // just before device booted is executed
 
-let CONFIG = {
+
+const sysStatus = Shelly.getComponentStatus('sys');
+
+const CONFIG = {
   scheduleSpecMatch: '* * SUN,MON,TUE,WED,THU,FRI,SAT',
 };
 
-let hour = null;
-let minutes = null;
+const hour = JSON.parse(sysStatus.time.slice(0, 2));
+const minutes = JSON.parse(sysStatus.time.slice(3, 5));
 
 function restoreSchedule() {
   if (hour === null || minutes === null) return;
@@ -55,8 +58,6 @@ function restoreSchedule() {
   });
 }
 
-Shelly.call('Sys.GetStatus', {}, function (status) {
-  hour = JSON.parse(status.time.slice(0, 2));
-  minutes = JSON.parse(status.time.slice(3, 5));
-  restoreSchedule();
-});
+
+restoreSchedule();
+

--- a/shelly1p-mqtt-autodiscover.js
+++ b/shelly1p-mqtt-autodiscover.js
@@ -32,27 +32,24 @@
 //
 // Cheers from https://bitekmindenhol.blog.hu/
 
+const deviceInfo = Shelly.getDeviceInfo();
+
 let CONFIG = {
-  shelly_id: null,
-  shelly_mac: null,
-  shelly_fw_id: null,
-  shelly_model: null,
+  shelly_id: deviceInfo.id,
+  shelly_mac: deviceInfo.mac,
+  shelly_fw_id: deviceInfo.fw_id,
+  shelly_model: deviceInfo.model,
   ha_mqtt_ad: "homeassistant",
-  device_name: "VIRTUAL_SWITCH",
+  device_name: deviceInfo.name || deviceInfo.id || "VIRTUAL_SWITCH",
   payloads: {
     on: "on",
     off: "off",
   },
   update_period: 30000,
 };
-Shelly.call("Shelly.GetDeviceInfo", {}, function (result) {
-  CONFIG.shelly_id = result.id;
-  CONFIG.shelly_mac = result.mac;
-  CONFIG.shelly_fw_id = result.fw_id;
-  CONFIG.device_name = result.name || result.id;
-  CONFIG.shelly_model = result.model;
-  initMQTT();
-});
+
+
+initMQTT();
 
 function buildMQTTConfigTopic(hatype, devname) {
   return (
@@ -108,10 +105,9 @@ Shelly.addStatusHandler(function (notification) {
 });
 
 function publishState() {
-  Shelly.call("Switch.GetStatus", { id: 0 }, function (result) {
-    let _temp = JSON.stringify(result.temperature.tC);
-    MQTT.publish(buildMQTTStateCmdTopics("temperature"), _temp);
-  });
+  const result = Shelly.getComponentStatus("Switch:0");
+  const _temp = JSON.stringify(result.temperature.tC);
+  MQTT.publish(buildMQTTStateCmdTopics("temperature"), _temp);
 }
 
 /**

--- a/shelly2p-domo-coverfix-v2.js
+++ b/shelly2p-domo-coverfix-v2.js
@@ -23,21 +23,18 @@
 // Extension for ShellyTeacher4Domo
 // https://github.com/enesbcs/shellyteacher4domo
 
-let CONFIG = {
-  shelly_id: null,
+const deviceInfo = Shelly.getDeviceInfo();
+
+const CONFIG = {
+  shelly_id: deviceInfo.id,
 };
-Shelly.call("Shelly.GetDeviceInfo", {}, function (result) {
- if (result && result.id) {
-  CONFIG.shelly_id = result.id;
-  MQTT.subscribe(
-    buildMQTTStateCmdTopics("rpc"),
-    DecodeDomoticzFaultyJSON
-  );
-  console.log("Subscribed to RPC");
- } else {
-  console.log("Failed to get Shelly device info:", result);
- }
-});
+
+MQTT.subscribe(
+  buildMQTTStateCmdTopics("rpc"),
+  DecodeDomoticzFaultyJSON
+);
+
+console.log("Subscribed to RPC");
 
 /**
  * @param {string} topic
@@ -52,22 +49,22 @@ function buildMQTTStateCmdTopics(topic) {
  * @param {string} message
  */
 function DecodeDomoticzFaultyJSON(topic, message) {
- try {
-  let trimmedMessage = message.trim();
-  if (trimmedMessage) {
-    if (trimmedMessage.indexOf("GoToPosition") !== -1){
-     let req = JSON.parse(trimmedMessage);
-     for (let r in req) {
-       if (r.indexOf("GoToPosition") !== -1) { // Check if "GoToPosition" is present in the key
-          SetCoverPosition(req[r]);
-          break;
-       }
-     }
+  try {
+    let trimmedMessage = message.trim();
+    if (trimmedMessage) {
+      if (trimmedMessage.indexOf("GoToPosition") !== -1) {
+        let req = JSON.parse(trimmedMessage);
+        for (let r in req) {
+          if (r.indexOf("GoToPosition") !== -1) { // Check if "GoToPosition" is present in the key
+            SetCoverPosition(req[r]);
+            break;
+          }
+        }
+      }
     }
+  } catch (error) {
+    console.log("Error parsing JSON:", error);
   }
- } catch (error) {
-   console.log("Error parsing JSON:", error);
- }
 }
 
 /**

--- a/shelly2p-domo-coverfix.js
+++ b/shelly2p-domo-coverfix.js
@@ -23,21 +23,17 @@
 // Extension for ShellyTeacher4Domo
 // https://github.com/enesbcs/shellyteacher4domo
 
-let CONFIG = {
-  shelly_id: null,
+const deviceInfo = Shelly.getDeviceInfo();
+
+const CONFIG = {
+  shelly_id: deviceInfo.id,
 };
-Shelly.call("Shelly.GetDeviceInfo", {}, function (result) {
- if (result && result.id) {
-  CONFIG.shelly_id = result.id;
-  MQTT.subscribe(
-    buildMQTTStateCmdTopics("rpc"),
-    DecodeDomoticzFaultyJSON
-  );
-  console.log("Subscribed to RPC");
- } else {
-  console.log("Failed to get Shelly device info:", result);
- }
-});
+
+MQTT.subscribe(
+  buildMQTTStateCmdTopics("rpc"),
+  DecodeDomoticzFaultyJSON
+);
+console.log("Subscribed to RPC");
 
 /**
  * @param {string} topic
@@ -54,14 +50,14 @@ function buildMQTTStateCmdTopics(topic) {
 function DecodeDomoticzFaultyJSON(topic, message) {
   let trimmedMessage = message.trim();
   if (trimmedMessage) {
-    if (trimmedMessage.indexOf("GoToPosition") !== -1){
-     let req = JSON.parse(trimmedMessage);
-     for (let r in req) {
-       if (r.indexOf("GoToPosition") !== -1) { // Check if "GoToPosition" is present in the key
+    if (trimmedMessage.indexOf("GoToPosition") !== -1) {
+      let req = JSON.parse(trimmedMessage);
+      for (let r in req) {
+        if (r.indexOf("GoToPosition") !== -1) { // Check if "GoToPosition" is present in the key
           SetCoverPosition(req[r]);
           break;
-       }
-     }
+        }
+      }
     }
   }
 }

--- a/test-scene.js
+++ b/test-scene.js
@@ -20,20 +20,12 @@
 // Demonstration of a "Remote Shelly" wrapper object. object prototyping, and
 // simple schene player
 
-let CONFIG = {
-  mac: 0,
-};
 
-Shelly.call(
-  "sys.getstatus",
-  {},
-  function (result, error_code, error_message, user_data) {
-    if (error_code === 0) {
-      CONFIG.mac = result.mac;
-    }
-  },
-  null
-);
+const sysStatus = Shelly.getComponentStatus('sys');
+
+let CONFIG = {
+  mac: sysStatus.mac,
+};
 
 let RemoteShelly = {
   _cb: function (result, error_code, error_message, callback) {


### PR DESCRIPTION
This example cannot get the correct BLU BTHome object, because it used a legacy decoding method. 
I've forgot to update it at [PR#132](https://github.com/ALLTERCO/shelly-script-examples/pull/132)
