### PR TITLE
Add text content headers

### DIFF
--- a/prometheus.js
+++ b/prometheus.js
@@ -84,6 +84,7 @@ function httpServerHandler(request, response) {
     }).join("")
   ].join("")
   response.code = 200;
+  response.headers = [['Content-Type', 'text/plain; version=0.0.4']]
   response.send();
 }
 


### PR DESCRIPTION
Prometheus would fail to scrape with the existing script. It seems more recent versions require the headers to be set. https://prometheus.io/docs/instrumenting/exposition_formats/#basic-info