### PR TITLE
Fix bug in extractBTHomeData at ble-pasv-mqtt-gw.js

### DIFF
--- a/ble-pasv-mqtt-gw.js
+++ b/ble-pasv-mqtt-gw.js
@@ -171,15 +171,15 @@ function extractBTHomeData(payload) {
        }
      }
      if (dataType >-1) {
-       let byteSize = datatypes[i][1];
-       let factor   = datatypes[i][3];
+       let byteSize = datatypes[dataType][1];
+       let factor   = datatypes[dataType][3];
        let rawdata = payload.slice(index, index + byteSize);
-       if (datatypes[i][2]) {
+       if (datatypes[dataType][2]) {
          value = convertByteArrayToSignedInt(rawdata, byteSize);
        } else {
          value = convertByteArrayToUnsignedInt(rawdata, byteSize);
        }
-       extractedData[ datatypes[i][4] ] = value * factor;
+       extractedData[ datatypes[dataType][4] ] = value * factor;
        index += byteSize;
      } else { index = 10;}
     }


### PR DESCRIPTION
The indexing was done with variable "i" which was out of the scope of lines 174 to 182.  

At line 169 a variable is filled to store the position of the specific data type, so "i" is replaced by "dataType" in the affected lines and now the code is working.

Hope this helps others, thanks for your great work!