### PR TITLE
Ble pasv mqtt gw refactor

### DIFF
--- a/ble-pasv-mqtt-gw.js
+++ b/ble-pasv-mqtt-gw.js
@@ -2,10 +2,24 @@
  * BLE passive scanner and MQTT gateway
  * Detected devices will be automatically registered to HA/Domoticz using MQTT Autodiscovery.
  *
- * Usage:
- *
+ * Quick instructions:
+ * 1. Run the scripts with default settings (debug enabled, filtering enabled)
+ * 2. Open script to see debug console
+ * 2. Press button of device you want to add or wait for it airs anything
+ * 3. Copy mac address from the debug console
+ * 4. Add mac to `allowed_devices` variable or `allowed_devices` KVS key. Read below for the data format
+ * 5. Restart script
+ * 6. Read debug for discovered device name.
+ * 7. Look for the device in HA
+ * 
+ * More information:
+ * 
  * Because BLE passive scanner process data of all surroudning BLE devices, this script allows to filter them by MAC address.
- * To do so enter the device data into `CONFIG.allowed_devicess` variable, or into KVS under `allowed_devicess` key.
+ * 
+ * IF `CONFIG.filter_devices` IS `true` (default), THEN
+ * ONLY BLE DEVICES IDENTIFIED BY MAC ADDRESSES FOUND IN `allowed_devicess` STRUCTURE WILL BE PROCESSED
+ * 
+ * MAC addresses can be set in `CONFIG.allowed_devicess` variable or into KVS under `allowed_devicess` key.
  * The KVS allows to add devices without need of changing the code of the script.
 
  * The format of those data is: { "<mac address>": [ "<manufacturer>", "<model>" ], } for example:
@@ -16,15 +30,15 @@
  *   "zzzzzzzzzzzz": [ "Shelly", "H&T BLU" ]
  * }
  *
- * The structure provides option to set manufacturer and model becuse those cannot be obtained from BLE messages.
- * Thanks to that this information can be passed to devices created via MQTT dicovery.
- * If you don't need that, pass empty array instead: { "3c2exxxxxxxx": [], }
+ * The manufacturer and model cannot be obtained from passive scan of BLE telegrams.
+ * Set into structure, contribute to MQTT dicovery.
+ * If you don't need that (not adviced), pass empty array instead: { "3c2exxxxxxxx": [], }
  *
  * Debugging:
  *
- * You can disable mac filtering at all by setting CONFIG.filter_devices to false.
+ * You can disable mac filtering at all by setting `CONFIG.filter_devices` to false.
  *
- * If CONFIG.debug is true, script will output mac addresses of ignored and processed devices to the console.
+ * If `CONFIG.debug` is true, script will output mac addresses of ignored and processed devices to the console.
  * Also it will output device and entity names, though once at time of registering them to MQTT Discovery.
  *
  * Supported payloads: ATC/Xiaomi/BTHomev2 through advertisements packets
@@ -33,96 +47,89 @@
  * Copyleft Alexander Nagy @ bitekmindenhol.blog.hu, Michal Bartak
  */
 
+
 const DEVICE_INFO = Shelly.getDeviceInfo();
 
 let CONFIG = {
-    /**
-     * If true, only selected devices will be processed.
-     * Selection of devices is achieved by setting up `CONFIG.allowed_devices` or (preferably) storing that information in KVS store under `allowed_devices` key.
-     *
-     * If false (not recommended), no filtering is applied, and all BLE messages are intercepted and passed to MQTT.
-     */
-    filter_devices: true,
+  /**
+   * If true, only selected devices will be processed.
+   * Selection of devices is achieved by setting up `CONFIG.allowed_devices` or (preferably) storing that information in KVS store under `allowed_devices` key.
+   *
+   * If false (not recommended), no filtering is applied, and all BLE messages are intercepted and passed to MQTT.
+   */
+  filter_devices: true,
 
-    /**
-     * If true, it will output:
-     * * MAC address of the ignored device
-     * * MAC address for processed device
-     * * If the device is discovered the first time, names of device and entities (to find them easier in HA))
-     */
-    debug: true,
+  /**
+   * If true, it will output:
+   * * MAC address of the ignored device
+   * * MAC address for processed device
+   * * If the device is discovered the first time, names of device and entities (to find them easier in HA))
+   */
+  debug: true,
 
-    /**
-     * Structure providing device data, identified by its MAC address
-     *
-     * IF `filter_devices` IS `true`, THEN
-     * ONLY BLE DEVICES IDENTIFIED BY MAC ADDRESSES FOUND IN THIS STRUCTURE WILL BE PROCESSED
-     *
-     * Data might also be stored in KVS under `allowed_devices` key (the same structure). It will be merged with the variable.\
-     * The script needs to be restarted to load changes from KVS.
-     *
-     * Examples:
-     * * `{ "xxxxfxxxxxxx": [ "Shelly", "DW BLU" ], }`
-     * * `{ "yyyyyyyyyyyy": [] }`
-     * Model and Manufacturer are optional. But missing won't be reported to MQTT Discovery as device properties.
-     */
-    allowed_devices: {},
+  /**
+   * Structure providing devices to be processed.
+   *
+   * Data might also be stored in KVS under `allowed_devices` key (the same structure). It will be merged data in the `CONFIG.allowed_devices` variable.\
+   * The script needs to be restarted to load changes from KVS.
+   *
+   * Examples:
+   * * `{ "macxxxxxxxxx": [ "Shelly", "DW BLU" ], }`
+   * * `{ "macyyyyyyyyy": [] }`
+   * Model and Manufacturer are optional. But then won't be reported to MQTT Discovery (model takes also a part in device name)
+   */
+  allowed_devices: {},
 
-    /**
-     * value added payload stored into mqtt_topic. Indicates a device which has stored the data (device the script is running on).
-     * Set to null to disable reporting.
-     */
-    mqtt_src: DEVICE_INFO.id + " (" + DEVICE_INFO.name + ")",
+  /**
+   * value added payload stored into mqtt_topic. Indicates a device which has stored the data (device the script is running on).
+   * Set to null to disable reporting.
+   */
+  mqtt_src: DEVICE_INFO.id + " (" + DEVICE_INFO.name + ")",
 
-    /**
-     * The KVS key, a user can set up allowed devices.
-     *
-     * Data has to be prepared as JSON. For structure, refer `CONFIG.allowed_devicess` description
-     */
-    kvs_key: "allowed_devices",
-    mqtt_topic: "blegateway/",
-    discovery_topic: "homeassistant/",
+  /**
+   * The KVS key, a user can set up allowed devices.
+   *
+   * Data has to be prepared as JSON. For structure, refer `CONFIG.allowed_devicess` description
+   */
+  kvs_key: "allowed_devices",
+  mqtt_topic: "blegateway/",
+  discovery_topic: "homeassistant/",
 
-    /**
-     * Possible values: `mqtt_event`, `device_trigger`.\
-     * Prefered one is: `mqtt_event` as most recent and better supported
-     */
-    buttons_as: "mqtt_event"
 };
 const SCAN_PARAM_WANT = { duration_ms: BLE.Scanner.INFINITE_SCAN, active: false }
 
 
 //BTHomev2: ID , Size, Sign, Factor, Name
 let datatypes = [
-    [0x00, 1, false, 1,    'pid'],
-    [0x01, 1, false, 1,    'battery'],
-    [0x12, 2, false, 1,    'co2'],
-    [0x0c, 2, false, 0.001,'voltage'],
-    [0x4a, 2, false, 0.1,  'voltage'],
-    [0x08, 2, true,  0.01, 'dewpoint'],
-    [0x03, 2, false, 0.01, 'humidity'],
-    [0x2e, 1, false, 1,    'humidity'],
-    [0x05, 3, false, 0.01, 'illuminance'],
-    [0x14, 2, false, 0.01, 'moisture'],
-    [0x2f, 1, false, 1,    'moisture'],
-    [0x04, 3, false, 0.01, 'pressure'],
-    [0x45, 2, true,  0.1,  'temperature'],
-    [0x02, 2, true,  0.01, 'temperature'],
-    [0x3f, 2, true,  0.1,  'rotation'],
-    [0x3a, 1, false, 1,    'button'], //selector
-    [0x15, 1, false, 1,    'battery_ok'], //binary
-    [0x16, 1, false, 1,    'battery_charging'], //binary
-    [0x17, 1, false, 1,    'co'], //binary
-    [0x18, 1, false, 1,    'cold'], //binary
-    [0x1a, 1, false, 1,    'door'], //binary
-    [0x1b, 1, false, 1,    'garage_door'], //binary
-    [0x1c, 1, false, 1,    'gas'], //binary
-    [0x1d, 1, false, 1,    'heat'], //binary
-    [0x1e, 1, false, 1,    'light'], //binary
-    [0x1f, 1, false, 1,    'lock'], //binary
-    [0x20, 1, false, 1,    'moisture_warn'], //binary
-    [0x21, 1, false, 1,    'motion'], //binary
-    [0x2d, 1, false, 1,    'window'], //binary
+  [0x00, 1, false, 1,    'pid'],
+  [0x01, 1, false, 1,    'battery'],
+  [0x12, 2, false, 1,    'co2'],
+  [0x0c, 2, false, 0.001,'voltage'],
+  [0x4a, 2, false, 0.1,  'voltage'],
+  [0x08, 2, true,  0.01, 'dewpoint'],
+  [0x03, 2, false, 0.01, 'humidity'],
+  [0x2e, 1, false, 1,    'humidity'],
+  [0x05, 3, false, 0.01, 'illuminance'],
+  [0x14, 2, false, 0.01, 'moisture'],
+  [0x2f, 1, false, 1,    'moisture'],
+  [0x04, 3, false, 0.01, 'pressure'],
+  [0x45, 2, true,  0.1,  'temperature'],
+  [0x02, 2, true,  0.01, 'temperature'],
+  [0x3f, 2, true,  0.1,  'rotation'],
+  [0x3a, 1, false, 1,    'button'], //selector
+  [0x15, 1, false, 1,    'battery_ok'], //binary
+  [0x16, 1, false, 1,    'battery_charging'], //binary
+  [0x17, 1, false, 1,    'co'], //binary
+  [0x18, 1, false, 1,    'cold'], //binary
+  [0x1a, 1, false, 1,    'door'], //binary
+  [0x1b, 1, false, 1,    'garage_door'], //binary
+  [0x1c, 1, false, 1,    'gas'], //binary
+  [0x1d, 1, false, 1,    'heat'], //binary
+  [0x1e, 1, false, 1,    'light'], //binary
+  [0x1f, 1, false, 1,    'lock'], //binary
+  [0x20, 1, false, 1,    'moisture_warn'], //binary
+  [0x21, 1, false, 1,    'motion'], //binary
+  [0x2d, 1, false, 1,    'window'], //binary
 ];
 
 let discovered = [];
@@ -213,85 +220,114 @@ let packedStruct = {
 };
 
 function convertByteArrayToSignedInt(bytes, byteSize) {
-    let result = 0;
-    const signBit = 1 << (byteSize * 8 - 1);
-    for (let i = 0; i < byteSize; i++) {
-        result |= (bytes.at(i) << (i * 8));
-    }
-    // Check sign bit and sign-extend if needed
-    if ((result & signBit) !== 0) {
-        result = result - (1 << (byteSize * 8));
-    }
-    return result;
+  let result = 0;
+  const signBit = 1 << (byteSize * 8 - 1);
+  for (let i = 0; i < byteSize; i++) {
+    result |= (bytes.at(i) << (i * 8));
+  }
+  // Check sign bit and sign-extend if needed
+  if ((result & signBit) !== 0) {
+    result = result - (1 << (byteSize * 8));
+  }
+  return result;
 };
 
 function convertByteArrayToUnsignedInt(bytes, byteSize) {
-    let result = 0;
-    for (let i = 0; i < byteSize; i++) {
-        result |= (bytes.at(i) << (i * 8));
-    }
-    return result >>> 0; // Ensure the result is an unsigned integer
+  let result = 0;
+  for (let i = 0; i < byteSize; i++) {
+    result |= (bytes.at(i) << (i * 8));
+  }
+  return result >>> 0; // Ensure the result is an unsigned integer
 };
 
 function extractBTHomeData(payload) {
-    let index = 0;
-    let extractedData = {};
-    while (index < payload.length) {
-     dataId = payload.at(index);
-     index = index + 1;
-     let dataType = -1;
-     for (let i=0; i<datatypes.length; i++) {
-       if (datatypes[i][0] == dataId) {
-         dataType = i;
-         break;
-       }
-     }
-     if (dataType >-1) {
-       let byteSize = datatypes[dataType][1];
-       let factor   = datatypes[dataType][3];
-       let rawdata = payload.slice(index, index + byteSize);
-       if (datatypes[dataType][2]) {
-         value = convertByteArrayToSignedInt(rawdata, byteSize);
-       } else {
-         value = convertByteArrayToUnsignedInt(rawdata, byteSize);
-       }
-       extractedData[ datatypes[dataType][4] ] = value * factor;
-       index += byteSize;
-     } else { index = 10;}
+  let index = 0;
+  let extractedData = {};
+  var button_ordinal = 0;
+  while (index < payload.length) {
+    dataId = payload.at(index);
+    index = index + 1;
+    let dataType = -1;
+    for (let i = 0; i < datatypes.length; i++) {
+      if (datatypes[i][0] == dataId) {
+        dataType = i;
+        break;
+      }
     }
+    if (dataType > -1) {
+      let byteSize = datatypes[dataType][1];
+      let factor = datatypes[dataType][3];
+      let rawdata = payload.slice(index, index + byteSize);
+      if (datatypes[dataType][2]) {
+        value = convertByteArrayToSignedInt(rawdata, byteSize);
+      } else {
+        value = convertByteArrayToUnsignedInt(rawdata, byteSize);
+      }
 
-    return extractedData;
+      // buttons data, expected in fixed order one after another
+      if (datatypes[dataType][0] == 0x3a) {
+
+        if (!extractedData[datatypes[dataType][4]]) {
+          extractedData[datatypes[dataType][4]] = [];
+        }
+
+        extractedData[datatypes[dataType][4]][button_ordinal] = convertIntToButtonEvent(value * factor);
+        button_ordinal++;
+      } else {
+        extractedData[datatypes[dataType][4]] = value * factor;
+      }
+
+      index += byteSize;
+    } else { index = 10; }
+  }
+
+  return extractedData;
 };
 
+/**
+ * Converts integer value of button event to textual representation
+ * @param {integer} intval
+ * @returns {string}
+ */
+function convertIntToButtonEvent(intval) {
+  switch (intval) {
+    case 0x00:
+      return 'none';
+    case 0x01:
+      return 'press';
+    case 0x02:
+      return 'double_press';
+    case 0x03:
+      return 'triple_press';
+    case 0x04:
+      return 'long_press';
+    case 0x80:
+      return 'hold';
+    case 0xFE:
+      return 'hold';
+    default:
+      return 'unsupported: ' + intval;
+  }
+}
 
 /**
- * Decides topic name for data
- *
- * Actually, this may break into pieces if the BLE payload differs between reports.
- * While for the topic alone it's ok, the topic is used as a part of a key to avoid repeating the discovery.
- *
+ * Determine topic name for data.\
+ * Depending on number of keys in provided struct, it returns:
+ * * name of key, if struct contains only one key provided struct contains only one key
+ * * `data` string if there are more keys.
+ * * empty string if no keys found
  * @param {<Object>} resarray Array of data
  * @returns {string} name of an MQTT topic to store data to
  */
 function getTopicName(resarray) {
-    let resstr = "";
-    let rlen = Object.keys(resarray).length;
-    if (rlen == 0) return resstr
-
-    if (rlen==1) {
-      resstr = Object.keys(resarray)[0];
-    } else if (("temperature" in resarray) || ("humidity" in resarray) || ("pressure" in resarray)) {
-      resstr = "sensor";
-    } else if ("battery" in resarray) {
-      resstr = "telemetry";
-    } else {
-      resstr = "status";
-    }
-    return resstr;
+  let rlen = Object.keys(resarray).length;
+  if (rlen == 0) return "";
+  if (rlen == 1) return Object.keys(resarray)[0];
+  return "data";
 }
 
 /**
- * Function creates and return a device data in format requierd by MQTT discovery.
+ * Function creates and returns a device data in format requierd by MQTT discovery.
  *
  * Manufacturer and model are retrieved from CONFIG.allowedMACs global variable.
  * Device name is built from its mac address and model name (if exists)
@@ -302,170 +338,163 @@ function getTopicName(resarray) {
  */
 function discoveryDevice(address) {
 
-    model="";
+  let model = "";
 
-    if (CONFIG.allowed_devices[address][1] !== undefined) {
-      model = CONFIG.allowed_devices[address][1];
-    }
+  if (CONFIG.allowed_devices[address][1] !== undefined) {
+    model = CONFIG.allowed_devices[address][1];
+  }
 
-    device = {};
-    device["name"]          = address + (model==="" ? "" : "-" + model);
-    device["identifiers"]   = [address];
-    device["connections"]   = [["mac", address]];
-    device["via_device"]    = normalizeMacAddress(DEVICE_INFO.mac);
+  device = {};
+  device["name"] = address + (model === "" ? "" : "-" + model);
+  device["ids"] = [address + ""];
+  device["cns"] = [["mac", address]];
+  device["via_device"] = normalizeMacAddress(DEVICE_INFO.mac);
 
-    if (CONFIG.allowed_devices[address][0] !== undefined) {
-      device["manufacturer"] = CONFIG.allowed_devices[address][0];
-    }
+  if (CONFIG.allowed_devices[address][0] !== undefined) {
+    device["mf"] = CONFIG.allowed_devices[address][0];
+  }
 
-    if (model !== "") {
-      device["model"] = model;
-    }
+  if (model !== "") {
+    device["mdl"] = model;
+  }
 
-    printDebug("Device name: ", device["name"]);
+  printDebug("Device name: ", device["name"]);
 
-    return device;
+  return device;
 }
 
 /**
  * Cretes and publishes discovery topic for single entity
- * @param {string} address MAC address of the BLE device
+ * @param {string} objident Object identifier used for preventing repeating discovery topic creation. Will be returned back in the result struct
  * @param {string} topic MQTT topic where data are reported to. Needed to include into Discovery definition
- * @param {string} name Data
- * @param {<Object>} device Device information to be added to dicovery data
+ * @param {string} objtype Name of object type. Mostly it will be borrowed for entity name
+ * @param {integer} bt_index 0-based index of button. Used to identify a button being a member of a multi-button device
+ * @return {<Object>} Object with data for publishing to MQTT
  */
-function discoveryEntity(address, topic, name, device) {
+function discoveryEntity(objident, topic, objtype, bt_index) {
 
-    let domain = "sensor"
+  let pload = {};
 
-    let pload = {};
-    pload["device"]  = device;
-    pload["name"]    = name;
-    pload["stat_t"]  = topic;
-    pload["val_tpl"] = "{{ value_json." + name + " }}";
+  // Some defaults. Might be overriden later
+  pload["name"]     = objtype;
+  pload["uniq_id"]  = objident;
+  pload["stat_t"]   = topic;
+  pload["val_tpl"]  = "{{ value_json." + objtype + " }}";
 
-    let subt = "";
+  let subt = "";
+  let domain;
 
-    switch (name) {
+  switch (objtype) {
 
-        /* SENSORS */
+    /* SENSORS */
 
-        case "temperature":
-        case "humidity":
-            domain                  = "sensor";
-            pload["dev_cla"]        = name;
-            pload["unit_of_meas"]   = name === "temperature" ? "°C" : "%";
-            subt                    = name;
-            break;
+    case "temperature":
+    case "humidity":
+      domain = "sensor";
+      pload["dev_cla"]      = objtype;
+      pload["stat_cla"]     = "measurement"
+      pload["unit_of_meas"] = objtype === "temperature" ? "°C" : "%";
+      subt = objtype;
+      break;
 
-        case "battery":
-            domain                  = "sensor";
-            pload["dev_cla"]        = "battery";
-            pload["ent_cat"]        = "diagnostic";
-            pload["unit_of_meas"]   = "%";
-            subt                    = "battery";
-            break;
+    case "battery":
+      domain = "sensor";
+      pload["dev_cla"]      = "battery";
+      pload["stat_cla"]     = "measurement"
+      pload["ent_cat"]      = "diagnostic";
+      pload["unit_of_meas"] = "%";
+      subt                  = "battery";
+      break;
 
-        case "illuminance":
-            domain                  = "sensor";
-            pload["dev_cla"]        = "illuminance";
-            pload["unit_of_meas"]   = "lx";
-            subt                    = "illuminance";
-            break;
+    case "illuminance":
+      domain = "sensor";
+      pload["dev_cla"]      = "illuminance";
+      pload["stat_cla"]     = "measurement"
+      pload["unit_of_meas"] = "lx";
+      subt                  = "illuminance";
+      break;
 
-        case "pressure":
-            domain                  = "sensor";
-            pload["dev_cla"]        = "atmospheric_pressure";
-            pload["unit_of_meas"]   = "hPa";
-            subt                    = "atmospheric_pressure";
-            break;
+    case "pressure":
+      domain                = "sensor";
+      pload["dev_cla"]      = "atmospheric_pressure";
+      pload["stat_cla"]     = "measurement"
+      pload["unit_of_meas"] = "hPa";
+      subt                  = "atmospheric_pressure";
+      break;
 
-        case "rssi":
-            domain                  = "sensor";
-            pload["dev_cla"]        = "signal_strength";
-            pload["ent_cat"]        = "diagnostic";
-            pload["unit_of_meas"]   = "dBm";
-            subt                    = "rssi";
-            break;
+    case "rssi":
+      domain                = "sensor";
+      pload["dev_cla"]      = "signal_strength";
+      pload["stat_cla"]     = "measurement"
+      pload["ent_cat"]      = "diagnostic";
+      pload["unit_of_meas"] = "dBm";
+      subt                  = "rssi";
+      break;
 
-        case "rotation":
-            pload["name"]           = "tilt";
-            domain                  = "sensor";
-            pload["unit_of_meas"]   = "°";
-            subt                    = "tilt";
-            pload["stat_t"]         = topic + "/rotation";
-            delete pload.val_tpl;
-            break;
+    case "rotation":
+      domain                = "sensor";
+      pload["name"]         = "tilt";
+      pload["stat_cla"]     = "measurement"
+      pload["unit_of_meas"] = "°";
+      pload["stat_t"] = topic + "/rotation";
+      subt                  = "tilt";
+      delete pload.val_tpl;
+      break;
 
-        /* BINARY SENSORS */
+    /* BINARY SENSORS */
 
-        case "window":
-            domain                  = "binary_sensor";
-            pload["name"]           = "contact";
-            pload["dev_cla"]        = "opening";
-            subt                    = "opening";
-            pload["pl_on"]          = 1;
-            pload["pl_off"]         = 0;
-            pload["stat_t"]         = topic + "/window";
-            delete pload.val_tpl;
-            break;
+    case "window":
+      domain                = "binary_sensor";
+      pload["name"]         = "contact";
+      pload["dev_cla"]      = "opening";
+      pload["pl_on"]        = 1;
+      pload["pl_off"]       = 0;
+      pload["stat_t"]       = topic + "/window";
+      subt                  = "opening";
+      delete pload.val_tpl;
+      break;
 
-        case "motion":
-            domain                  = "binary_sensor";
-            pload["dev_cla"]        = "motion";
-            subt                    = "motion";
-            pload["pl_on"]          = 1;
-            pload["pl_off"]         = 0;
-            break;
+    case "motion":
+      domain                = "binary_sensor";
+      pload["dev_cla"]      = "motion";
+      pload["pl_on"]        = 1;
+      pload["pl_off"]       = 0;
+      subt                  = "motion";
+      break;
 
-        /* BUTTON */
+    /* BUTTONS */
 
-        case "button":
+    case "button":
 
-            switch (CONFIG.buttons_as) {
-                case "mqtt_event":
-                    domain                  = "event";
-                    pload["platform"]       = "event";
-                    pload["device_class"]   = "button";
-                    pload["event_types"]    = ["click"];
+      domain = "event";
+      pload["p"]     = "event";
+      pload["dev_cla"] = "button";
+      pload["evt_typ"]  = ["none", "press", "double_press", "triple_press", "long_press", "hold"];
 
-                    pload["name"]           = "button";
-                    subt                    = pload["name"];
-                    pload["state_topic"]    = topic;
-                    pload["val_tpl"] = ' \
-{ {% if  value_json.get("button") %} \
-"button": "button", \
-"event_type": "click" \
-{% endif %} }';
-                    break;
-                case "device_trigger":
-                    domain                  = "device_automation";
-                    pload["automation_type"]= "trigger";
-                    pload["platform"]       = "device_automation";
-                    pload["type"]           = "action";
-                    pload["subtype"]        = "button_click";
-                    subt                    = pload["type"] + "_" +  pload["subtype"];
-                    pload["payload"]        = "1";
-                    pload["topic"]          = topic;
-                    break;
-            }
-            break;
-        default:
-            printDebug("Unrecognized param: ", name);
-            return;
-            break;
-    }
+      if (bt_index == -1) {
+        pload["name"]       = "button"
+        subt                = "button";
+      } else {
+        pload["name"]       = "button " + (bt_index + 1);
+        subt                = "button-" + (bt_index + 1);
+      }
+      
+      if (bt_index == -1) bt_index = 0;
+      
+      pload["stat_t"]       = topic;
+      pload["val_tpl"]      = '{% set buttons = value_json.get("button") %} \
+{ {%- if buttons and buttons[' + bt_index + '] != "none" -%} \
+"button": "button", "event_type": "{{ buttons[' + bt_index + '] }}" \
+{%- endif -%} }';
+        
+      break;
+    default:
+      printDebug("Unrecognized obj type: ", objtype, ". Ignored");
+      return;
+      break;
+  }
 
-    // has to be after the case statement, because of pload["name"]
-    pload["uniq_id"] = address + "-" + pload["name"];
-
-    if (domain === "sensor") pload["stat_cla"] = "measurement";
-
-    let discoveryTopic = CONFIG.discovery_topic + domain + "/" + address + "/" + subt + "/config";
-    printDebug("Discovered: ", pload["name"], "; path", discoveryTopic );
-
-    let adstr = {"topic": discoveryTopic, "data": pload};
-    MQTT.publish(adstr.topic + "", JSON.stringify(adstr.data), 1, true);
+  return { "objident": objident, "domain": domain, "subtopic": subt, "data": pload }
 }
 
 
@@ -481,7 +510,7 @@ function normalizeMacAddress(address) {
 /**
  * Determines whethere device identified by the `address` has to be processed or skipped.
  * @param {string} address Normalized form of MAC address
- * @returns {bool}
+ * @returns {bool} False if device has to be skipped. Otherwise true.
  */
 function allowDevices(address) {
   if (!CONFIG.filter_devices) return true;
@@ -503,58 +532,77 @@ function allowDevices(address) {
 function discoveryItems(address, topic, jsonstr) {
 
   let params = Object.keys(jsonstr);
-  let device = discoveryDevice(address);
+  let ploads = [];
 
   // Iterate through all values, even unsupported.
   // Not supported params will be ignored within autodiscovery()
   // then stored into `discovered` array and never processed again.
   for (let i = 0; i < params.length; i++) {
-
-    let discKey = address+params[i];
-
-    if (discovered.indexOf(discKey) == -1) {
-
-      discoveryEntity(address, topic, params[i], device);
-
-      discovered.push(discKey); //mark as discovered
+    let objtype = params[i];
+    if (objtype == 'button' && jsonstr['button'].length > 1) { // pass only multiple buttons
+      for (let b = 0; b < jsonstr['button'].length; b++) {
+        let objident = address + "-" + objtype + "-" + (b + 1);
+        if (discovered.indexOf(objident) == -1) {
+          ploads.push(discoveryEntity(objident, topic, objtype, b));
+        }
+      }
+    }
+    else {
+      let objident = address + "-" + objtype;
+      if (discovered.indexOf(objident) == -1) {
+        ploads.push(discoveryEntity(objident, topic, objtype, -1)); // we need that -1 in case of single button device (simplifies its name)
+      }
     }
   }
 
+  for (let i = 0; i < ploads.length; i++) {
+
+    if (ploads[i] === undefined) continue;
+
+    ploads[i].data.device = discoveryDevice(address);
+    let discoveryTopic = CONFIG.discovery_topic + ploads[i].domain + "/" + address + "/" + ploads[i].subtopic + "/config";
+
+    MQTT.publish(discoveryTopic, JSON.stringify(ploads[i].data), 1, true);
+    printDebug("Discovered: ", ploads[i].data.name, "; path", discoveryTopic);
+
+    discovered.push(ploads[i].objident); //mark as discovered
+  }
 }
 
 function mqttreport(address, rssi, jsonstr) {
-    let macNormalized = normalizeMacAddress(address);
 
-    if (!allowDevices(macNormalized)) {
-      printDebug("Ignored MAC: ", macNormalized);
-      return;
-    }
+  let macNormalized = normalizeMacAddress(address);
 
-    printDebug("Processed MAC: ", macNormalized);
-    printDebug("Data: ", JSON.stringify(jsonstr));
+  if (!allowDevices(macNormalized)) {
+    printDebug("Ignored MAC: ", macNormalized);
+    return;
+  }
 
-    let topname = getTopicName(jsonstr);
-    let topic = CONFIG.mqtt_topic + macNormalized + "/" + topname;
-    printDebug("Topic:", topic);
+  printDebug("Processed MAC: ", macNormalized);
+  printDebug("Data: ", JSON.stringify(jsonstr));
 
-    jsonstr['rssi'] = rssi;
-    if (CONFIG.mqtt_src) {
-        jsonstr['src'] = CONFIG.mqtt_src;
-    }
+  let topic = CONFIG.mqtt_topic + macNormalized + "/" + getTopicName(jsonstr);
+  printDebug("Topic:", topic);
 
-    discoveryItems(macNormalized, topic, jsonstr);
+  jsonstr['rssi'] = rssi;
+  if (CONFIG.mqtt_src) {
+    jsonstr['src'] = CONFIG.mqtt_src;
+  }
 
-    MQTT.publish(topic, JSON.stringify(jsonstr), 1, false);
+  // Create discovery entries if needed
+  discoveryItems(macNormalized, topic, jsonstr);
 
-    // Need to store those parameters into separate topics, since they are not reported with every message.
-    // It renders in unavailable state on HA restart
-    if (jsonstr.hasOwnProperty('window')) {
-        MQTT.publish(topic + '/window', JSON.stringify(jsonstr.window), 1, true);
-    }
+  MQTT.publish(topic, JSON.stringify(jsonstr), 1, false);
 
-    if (jsonstr.hasOwnProperty('rotation')) {
-        MQTT.publish(topic + '/rotation', JSON.stringify(jsonstr.rotation), 1, true);
-    }
+  // Need to store those parameters into separate topics, since they are not reported with every message.
+  // It renders in unavailable state on HA restart
+  if (jsonstr.hasOwnProperty('window')) {
+    MQTT.publish(topic + '/window', JSON.stringify(jsonstr.window), 1, true);
+  }
+
+  if (jsonstr.hasOwnProperty('rotation')) {
+    MQTT.publish(topic + '/rotation', JSON.stringify(jsonstr.rotation), 1, true);
+  }
 
 }
 
@@ -685,14 +733,14 @@ init();
  * Outputs passed arguments to console, only if `CONFIG.debug` is true
  */
 function printDebug() {
-    if (!CONFIG.debug) return;
+  if (!CONFIG.debug) return;
 
-    let str = "";
-    for (let i = 0; i < arguments.length; i++) {
-      str = str + arguments[i];
-    }
+  let str = "";
+  for (let i = 0; i < arguments.length; i++) {
+    str = str + arguments[i];
+  }
 
-    console.log(str);
+  console.log(str);
 }
 
 
@@ -704,20 +752,20 @@ function printDebug() {
  * @async
  */
 function kvsGet(key, callback) {
-    Shelly.call(
-        "KVS.Get",
-        { key: key },
-        function (result, error) {
-            if (error == -105) {
-                printDebug("No `" + key + "` key found in KVS. It's OK if you don't need that");
-            } else if (error) {
-                print("KVS Get Error:", JSON.stringify(error));
-                callback(null);
-            } else {
-                callback(result.value);
-            }
-        }
-    );
+  Shelly.call(
+    "KVS.Get",
+    { key: key },
+    function (result, error) {
+      if (error == -105) {
+        printDebug("No `" + key + "` key found in KVS. It's OK if you don't need that");
+      } else if (error) {
+        print("KVS Get Error:", JSON.stringify(error));
+        callback(null);
+      } else {
+        callback(result.value);
+      }
+    }
+  );
 }
 
 
@@ -728,19 +776,20 @@ function kvsGet(key, callback) {
  * @async
  */
 function loadBleMacsFromKVS(callback) {
-    kvsGet(CONFIG.kvs_key, function(value) {
-        if (value !== null) {
-            let macs = JSON.parse(value);
+  kvsGet(CONFIG.kvs_key, function (value) {
+    if (value !== null) {
+      let macs = JSON.parse(value);
 
-            for (let k in macs) {
-              CONFIG.allowed_devices[normalizeMacAddress(k)] = macs[k];
-            }
-        }
-        callback();
-    });
+      for (let k in macs) {
+        CONFIG.allowed_devices[normalizeMacAddress(k)] = macs[k];
+      }
+    }
+    callback();
+  });
 }
 
-loadBleMacsFromKVS(function() {
+
+loadBleMacsFromKVS(function () {
   if (Object.keys(CONFIG.allowed_devices).length == 0 && CONFIG.filter_devices) {
     printDebug("No devices will be processed beucase filter_devices is true and allowed_devices are not set");
   }
@@ -749,8 +798,8 @@ loadBleMacsFromKVS(function() {
     let msg = "Devices configured for processing:\n";
     for (let k in CONFIG.allowed_devices) {
       msg = msg + "\n" + "MAC: " + k
-              + "; Manufacturer: " + (CONFIG.allowed_devices[k][0] === undefined ? "<none>" : CONFIG.allowed_devices[k][0])
-              + "; Model: " + (CONFIG.allowed_devices[k][1] === undefined ? "<none>" : CONFIG.allowed_devices[k][1]);
+        + "; Manufacturer: " + (CONFIG.allowed_devices[k][0] === undefined ? "<none>" : CONFIG.allowed_devices[k][0])
+        + "; Model: " + (CONFIG.allowed_devices[k][1] === undefined ? "<none>" : CONFIG.allowed_devices[k][1]);
     }
 
     printDebug(msg);


### PR DESCRIPTION
# ble pasv mqtt gw overhaul

This PR introduces several changes, including fixes, refactors, and new features. All are focused on Discovery while BLE code remains untouched (almost... support of multi-button devices has required some touches)

## Major changes:

### New features
1. Added support for Shelly Door/Window BLE, Buttons BLE (H&T, RC Button 4 etc.)
   * Buttons are reported with the use of MQTT events
1. Added MACs filtering (incl option to use KVS)
1. Added (optional) Manufacturer/Model,
1. Added `connections`, `identifiers`, and `via_device` to the MQTT discovered device
1. Debug to the console, helping in adding a new device (enabled by default, with an option to disable it)

### Improvements
1. Fixed Celsius units
1. Fixed sensors possibly changing their topic (see breaking changes)
1. Fixed window state and tilt turned unknown when restarting HA
   * It's because BLE devices don't always report these attributes, so after HA restart, they are missing from the  retained message
1. Rotation state renamed  to Tilt
1. Window renamed to Opening, and window class renamed to Opening. Both to allow better flexibility (ie for doors)
1. optimizations
   * The device is rendered for a processed device only once
   * More abbreviations used within MQTT discovery
1. More detailed documentation

![image](https://github.com/user-attachments/assets/64e26ff1-40d3-44db-9cfb-69f66425e4b3)


## Breaking changes:

**The data are no longer stored in `sensor`, `telemetry`, and `status` topics. The new common topic is `data`.** 
> It will not impact users who rely on discovery
<details>
<summary>Click for details</summary>
There are multiple reasons for that:

1. Reported values may belong to different classes, for example, temperature -> sensor, RSSI -> telemetry. 
1. The first message determines creation of MQTT discovery objects incl. data topic. A different set of sensors in subsequent messages might cause pointing to a different topic
1. Sensors don't guarantee that all their values are reported at once. For example, RSSI might be reported with a button, or with temperature (case of Shelly H&T BLE)

It turns out that depending on the combination of values in the event, particular values might got their topic changed as time goes by.
</details>

**Changed naming schema**
* Devices will be named with the format: `mac-model` or `mac` if the model is not provided
* Names of discovered entities will be set to object type, ie `pressure`. 
* `unique_id` of entities is set to `mac-type` (`xxxxxxxxx-window`) or `mac-type-index` (`xxxxxxxxxxx-button-2`)

<details>
<summary>Click for details</summary>
Change to the naming aligns final device and entity names with Home Assistant standards. 

HA will name the entity to `devicename name`, for example: `1a2b3c4d5e6f-H&T BLU Temperature`. Then, renaming the device gives an option to automatically rename entities in order to follow the device name change. For example, changing the name of the device to `PCROOM HT` will (after confirmation) turn the entity name into `PCROOM HT Temperature`.

On top of that, some HA pages (ie, device view) can strip the device name out of the entity name, making them shorter and less cluttered.
</details>