### PR TITLE
Implement try-catch in remoteControl function

### DIFF
--- a/switch-input/n-way-dimmer.shelly.js
+++ b/switch-input/n-way-dimmer.shelly.js
@@ -59,12 +59,16 @@ function setWifiIP() {
 // @param {string} method Control method
 // @param {object} body 
 function remoteControl(ip, method, body, cb) {
-  const postData = {
-    url: "http://" + ip + "/rpc/" + method,
-    body: JSON.stringify(body),
-  };
-
-  Shelly.call("HTTP.POST", postData, cb);
+  try {
+    const postData = {
+      url: "http://" + ip + "/rpc/" + method,
+      body: JSON.stringify(body),
+    };
+  
+    Shelly.call("HTTP.POST", postData, cb);
+  } catch (err) {
+    console.log("Remote control exception: ", err)
+  }
 }
 
 // ***********************************************************************


### PR DESCRIPTION
Ran into an issue where occasionally the script would stop running due to an exception within the remote control call. The exception was seemingly related to being rate limited by the switches it was sending the call to.