### PR TITLE
Add Plus Plug S LED power states script

### DIFF
--- a/SHELLY_MJS.md
+++ b/SHELLY_MJS.md
@@ -335,9 +335,9 @@ power-energy/monitor-production.shelly.js: Add Additional Meter to the Advanced 
 ===
 Use this script paired with advanced-load-shedding.shelly.js to add a second source - example, grid, PV, generator, etc.
 
-power-energy/plus-plug-s-led-power-states.shelly.js: Shelly Plus Plug S LED power states
+power-energy/plus-plug-s-led-power-states.shelly.js: Shelly Plus Plug S LED power visualization
 ===
-Shows current power consumption as clear LED ring states on a Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and appliance power usage feedback without opening an app.
+Shows current power consumption as clear LED ring states or a green-to-red gradient on a Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and appliance power usage feedback without opening an app.
 
 power-energy/power-outages.shelly.js: Monitor Power Outages or Crashed Services
 ===

--- a/SHELLY_MJS.md
+++ b/SHELLY_MJS.md
@@ -335,6 +335,10 @@ power-energy/monitor-production.shelly.js: Add Additional Meter to the Advanced 
 ===
 Use this script paired with advanced-load-shedding.shelly.js to add a second source - example, grid, PV, generator, etc.
 
+power-energy/plus-plug-s-led-power-states.shelly.js: Shelly Plus Plug S LED power states
+===
+Shows current power consumption as clear LED ring states on a Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and appliance power usage feedback without opening an app.
+
 power-energy/power-outages.shelly.js: Monitor Power Outages or Crashed Services
 ===
 Monitors any device or service that returns data from HTTP/HTTPS requests. Executes webhooks and/or updates MQTT topics.

--- a/examples-manifest.json
+++ b/examples-manifest.json
@@ -389,6 +389,11 @@
     "description": "Use this script paired with advanced-load-shedding.shelly.js to add a second source - example, grid, PV, generator, etc."
   },
   {
+    "fname": "power-energy/plus-plug-s-led-power-states.shelly.js",
+    "title": "Shelly Plus Plug S LED power states",
+    "description": "Shows current power consumption as clear LED ring states on a Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and appliance power usage feedback without opening an app."
+  },
+  {
     "fname": "power-energy/power-outages.shelly.js",
     "title": "Monitor Power Outages or Crashed Services",
     "description": "Monitors any device or service that returns data from HTTP/HTTPS requests. Executes webhooks and/or updates MQTT topics."

--- a/examples-manifest.json
+++ b/examples-manifest.json
@@ -390,8 +390,8 @@
   },
   {
     "fname": "power-energy/plus-plug-s-led-power-states.shelly.js",
-    "title": "Shelly Plus Plug S LED power states",
-    "description": "Shows current power consumption as clear LED ring states on a Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and appliance power usage feedback without opening an app."
+    "title": "Shelly Plus Plug S LED power visualization",
+    "description": "Shows current power consumption as clear LED ring states or a green-to-red gradient on a Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and appliance power usage feedback without opening an app."
   },
   {
     "fname": "power-energy/power-outages.shelly.js",

--- a/power-energy/README.md
+++ b/power-energy/README.md
@@ -11,6 +11,7 @@ Use these to monitor consumption and automatically manage loads to stay within p
 - `failure-monitor.shelly.js`
 - `load-shedding.shelly.js`
 - `monitor-production.shelly.js`
+- `plus-plug-s-led-power-states.shelly.js`
 - `power-outages.shelly.js`
 - `power-threshold-limit-output.shelly.js`
 - `victron-mppt-solar-controller.shelly.js`

--- a/power-energy/plus-plug-s-led-power-states.shelly.js
+++ b/power-energy/plus-plug-s-led-power-states.shelly.js
@@ -1,0 +1,110 @@
+/**
+ * @title Shelly Plus Plug S LED power states
+ * @description Shows current power consumption as clear LED ring states on a
+ *   Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and
+ *   appliance power usage feedback without opening an app.
+ * @status production
+ * @link https://github.com/ALLTERCO/shelly-script-examples/blob/main/power-energy/plus-plug-s-led-power-states.shelly.js
+ */
+
+// Shelly Script example: Shelly Plus Plug S LED power states
+//
+// This script reads Switch.GetStatus.apower and changes the Plug S LED ring to
+// show live consumption at a glance:
+//   < 5 W    - off
+//   5-25 W   - green
+//   25-60 W  - warm yellow
+//   60-100 W - orange
+//   >= 100 W - red
+//
+// RGB values for PLUGS_UI are 0-100 per channel, not 0-255.
+// The script updates PLUGS_UI only when the visual state changes.
+
+let CONFIG = {
+  noConsumptionW: 5,
+  greenBelowW: 25,
+  yellowBelowW: 60,
+  orangeBelowW: 100,
+  pollMs: 2000,
+  brightness: 100,
+};
+
+let lastState = "";
+let updating = false;
+
+function powerState(power) {
+  if (power < CONFIG.noConsumptionW) {
+    return { name: "off", rgb: [0, 0, 0], brightness: 0 };
+  }
+  if (power < CONFIG.greenBelowW) {
+    return { name: "green", rgb: [0, 100, 0], brightness: CONFIG.brightness };
+  }
+  if (power < CONFIG.yellowBelowW) {
+    return { name: "yellow", rgb: [100, 70, 0], brightness: CONFIG.brightness };
+  }
+  if (power < CONFIG.orangeBelowW) {
+    return { name: "orange", rgb: [100, 35, 0], brightness: CONFIG.brightness };
+  }
+  return { name: "red", rgb: [100, 0, 0], brightness: CONFIG.brightness };
+}
+
+function setLed(state) {
+  let stateKey = [
+    state.name,
+    state.rgb[0],
+    state.rgb[1],
+    state.rgb[2],
+    state.brightness,
+  ].join(":");
+
+  if (stateKey === lastState || updating) return;
+
+  let config = {
+    leds: {
+      mode: "switch",
+      colors: {
+        "switch:0": {
+          on: { rgb: state.rgb, brightness: state.brightness },
+          off: { rgb: state.rgb, brightness: state.brightness },
+        },
+      },
+    },
+  };
+
+  updating = true;
+  Shelly.call(
+    "HTTP.GET",
+    {
+      url:
+        "http://localhost/rpc/PLUGS_UI.SetConfig?config=" +
+        JSON.stringify(config),
+      timeout: 5,
+    },
+    function (result, errorCode, errorMessage) {
+      updating = false;
+      if (errorCode === 0) {
+        lastState = stateKey;
+      } else {
+        print("LED update failed:", errorCode, errorMessage);
+      }
+    }
+  );
+}
+
+function updateLedFromPower() {
+  Shelly.call(
+    "Switch.GetStatus",
+    { id: 0 },
+    function (status, errorCode, errorMessage) {
+      if (errorCode !== 0) {
+        print("Switch.GetStatus failed:", errorCode, errorMessage);
+        return;
+      }
+
+      setLed(powerState(status.apower || 0));
+    }
+  );
+}
+
+Timer.set(CONFIG.pollMs, true, updateLedFromPower);
+updateLedFromPower();

--- a/power-energy/plus-plug-s-led-power-states.shelly.js
+++ b/power-energy/plus-plug-s-led-power-states.shelly.js
@@ -1,30 +1,30 @@
 /**
- * @title Shelly Plus Plug S LED power states
- * @description Shows current power consumption as clear LED ring states on a
- *   Shelly Plus Plug S. Useful for visual homelab, workstation, charger, and
- *   appliance power usage feedback without opening an app.
+ * @title Shelly Plus Plug S LED power visualization
+ * @description Shows current power consumption as clear LED ring states or a
+ *   green-to-red gradient on a Shelly Plus Plug S. Useful for visual homelab,
+ *   workstation, charger, and appliance power usage feedback without opening
+ *   an app.
  * @status production
  * @link https://github.com/ALLTERCO/shelly-script-examples/blob/main/power-energy/plus-plug-s-led-power-states.shelly.js
  */
 
-// Shelly Script example: Shelly Plus Plug S LED power states
+// Shelly Script example: Shelly Plus Plug S LED power visualization
 //
 // This script reads Switch.GetStatus.apower and changes the Plug S LED ring to
 // show live consumption at a glance:
-//   < 5 W    - off
-//   5-25 W   - green
-//   25-60 W  - warm yellow
-//   60-100 W - orange
-//   >= 100 W - red
+//   mode "states"   - off, green, warm yellow, orange, red by thresholds
+//   mode "gradient" - smooth green -> yellow -> red up to gradientMaxW
 //
 // RGB values for PLUGS_UI are 0-100 per channel, not 0-255.
 // The script updates PLUGS_UI only when the visual state changes.
 
 let CONFIG = {
+  mode: "states", // Use "states" or "gradient".
   noConsumptionW: 5,
   greenBelowW: 25,
   yellowBelowW: 60,
   orangeBelowW: 100,
+  gradientMaxW: 100,
   pollMs: 2000,
   brightness: 100,
 };
@@ -32,7 +32,13 @@ let CONFIG = {
 let lastState = "";
 let updating = false;
 
-function powerState(power) {
+function clamp(value, min, max) {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function fixedPowerState(power) {
   if (power < CONFIG.noConsumptionW) {
     return { name: "off", rgb: [0, 0, 0], brightness: 0 };
   }
@@ -46,6 +52,37 @@ function powerState(power) {
     return { name: "orange", rgb: [100, 35, 0], brightness: CONFIG.brightness };
   }
   return { name: "red", rgb: [100, 0, 0], brightness: CONFIG.brightness };
+}
+
+function gradientPowerState(power) {
+  if (power < CONFIG.noConsumptionW) {
+    return { name: "off", rgb: [0, 0, 0], brightness: 0 };
+  }
+
+  let ratio = clamp(power / CONFIG.gradientMaxW, 0, 1);
+  let red = 0;
+  let green = 100;
+
+  if (ratio < 0.5) {
+    red = Math.round(ratio * 200);
+  } else {
+    red = 100;
+    green = Math.round(100 - ((ratio - 0.5) * 200));
+  }
+
+  return {
+    name: "gradient",
+    rgb: [red, green, 0],
+    brightness: CONFIG.brightness,
+  };
+}
+
+function powerState(power) {
+  if (CONFIG.mode === "gradient") {
+    return gradientPowerState(power);
+  }
+
+  return fixedPowerState(power);
 }
 
 function setLed(state) {


### PR DESCRIPTION
## Summary
- Add a Shelly Plus Plug S script that maps active power draw to clear LED ring states.
- Helps visualize consumption for homelabs, workstations, chargers, appliances, and other plugged-in devices without opening an app.
- Update the power-energy manifest, README, and generated script index.

## Test plan
- Tested the script on a Shelly Plus Plug S running firmware 1.7.5.
- Verified LED states on a live device for idle, low-consumption, and workstation-load readings.
- Ran `python3 tools/check-manifest-integrity.py --check-headers --check-sync --check-index`.

Note: `--check-indent` currently reports pre-existing indentation issues in unrelated scripts in this repository, so it was not included in the final passing validation command.

Made with [Cursor](https://cursor.com)