### PR TITLE
Fix BLE enable check aborting scripts on firmware 2.0.0

### DIFF
--- a/ble/ble-shelly-blu.shelly.js
+++ b/ble/ble-shelly-blu.shelly.js
@@ -264,7 +264,7 @@ function init() {
   const BLEConfig = Shelly.getComponentConfig("ble");
 
   //exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  if (BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );


### PR DESCRIPTION
Shelly.getComponentConfig("ble") no longer returns a top-level `enable` key on firmware 2.0.0 (confirmed on a Plug S Gen3, 20260710-101146/2.0.0). The existing `!BLEConfig.enable` guard reads that absence as "Bluetooth is disabled" and returns before BLE.Scanner.Subscribe(), so the script never receives any advertisements.

The failure is silent: Script.GetStatus still reports running:true and nothing is logged past the initial error line, so an affected gateway looks healthy while relaying nothing. On the same device BLE.GetStatus reports flags ["advertising","scanning"] — Bluetooth is on, only the config shape changed.

Check for an explicit `false` instead. That still behaves correctly on Gen2 firmware (verified on a BLU Gateway, 1.7.5), which does send `enable: true`.