### PR TITLE
fix(ble): don't abort when ble.enable is absent on firmware 2.0.0+

### DIFF
--- a/ble/ble-PTM215B-button.shelly.js
+++ b/ble/ble-PTM215B-button.shelly.js
@@ -90,8 +90,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-aranet2.shelly.js
+++ b/ble/ble-aranet2.shelly.js
@@ -281,8 +281,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-aranet4.shelly.js
+++ b/ble/ble-aranet4.shelly.js
@@ -292,8 +292,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-bparasite.shelly.js
+++ b/ble/ble-bparasite.shelly.js
@@ -59,8 +59,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-miflora-xiaomi-hhccjcy01.shelly.js
+++ b/ble/ble-miflora-xiaomi-hhccjcy01.shelly.js
@@ -151,8 +151,8 @@ function init() {
     // get the config of ble component
     const BLEConfig = Shelly.getComponentConfig("ble");
 
-    // exit if the BLE isn't enabled
-    if (!BLEConfig.enable) {
+    // exit only if the BLE is explicitly disabled
+    if (BLEConfig && BLEConfig.enable === false) {
         console.log(
             "Error: The Bluetooth is not enabled, please enable it from settings"
         );

--- a/ble/ble-mopeka.shelly.js
+++ b/ble/ble-mopeka.shelly.js
@@ -106,8 +106,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-pasv-mqtt-gw.shelly.js
+++ b/ble/ble-pasv-mqtt-gw.shelly.js
@@ -371,8 +371,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-ruuvi.shelly.js
+++ b/ble/ble-ruuvi.shelly.js
@@ -148,8 +148,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-shelly-blu.shelly.js
+++ b/ble/ble-shelly-blu.shelly.js
@@ -263,8 +263,8 @@ function init() {
   //get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  //exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  //exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-shelly-btn-gateway-for-other-devices.shelly.js
+++ b/ble/ble-shelly-btn-gateway-for-other-devices.shelly.js
@@ -265,8 +265,8 @@ function bleScan() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-shelly-btn.shelly.js
+++ b/ble/ble-shelly-btn.shelly.js
@@ -261,8 +261,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-shelly-dw.shelly.js
+++ b/ble/ble-shelly-dw.shelly.js
@@ -256,8 +256,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-shelly-motion.shelly.js
+++ b/ble/ble-shelly-motion.shelly.js
@@ -260,8 +260,8 @@ function init() {
   //get the config of ble component
   let BLEConfig = Shelly.getComponentConfig("ble");
 
-  //exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  //exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/ble-shelly-scanner.shelly.js
+++ b/ble/ble-shelly-scanner.shelly.js
@@ -44,8 +44,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );

--- a/ble/universal-blu-to-mqtt.shelly.js
+++ b/ble/universal-blu-to-mqtt.shelly.js
@@ -189,8 +189,8 @@ function init() {
   // get the config of ble component
   const BLEConfig = Shelly.getComponentConfig("ble");
 
-  // exit if the BLE isn't enabled
-  if (!BLEConfig.enable) {
+  // exit only if the BLE is explicitly disabled
+  if (BLEConfig && BLEConfig.enable === false) {
     console.log(
       "Error: The Bluetooth is not enabled, please enable it from settings"
     );


### PR DESCRIPTION
## Problem

Firmware 2.0.0 removed the global BLE enable flag. From the [gen2+ changelog](https://shelly-api-docs.shelly.cloud/gen2/changelog/#200-2026-07-13), under _Removed_:

> **BLE**: Remove global enable flag from config (auto-activate/deactivate scanning) **BREAKING CHANGE**

and the [BLE component docs](https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/BLE) now state that the `enable` property has been removed, with scanning auto-activating when a script, the BLU gateway or BTHome needs it.

Fifteen scripts in this repository open `init()` with:

```js
const BLEConfig = Shelly.getComponentConfig("ble");

//exit if the BLE isn't enabled
if (!BLEConfig.enable) {
  console.log("Error: The Bluetooth is not enabled, please enable it from settings");
  return;
}
```

On 2.0.0 and newer the flag is simply absent, so `!undefined` is `true` and every one of these scripts returns **before it subscribes to the scanner**. Nothing is scanned and no event is emitted.

What makes it hard to diagnose is that the device still reports the script as `running`: it starts, prints `Error: The Bluetooth is not enabled, please enable it from settings` to the script console, and then quietly does nothing. It reads as a device or Bluetooth problem rather than a script one.

This surfaced downstream as [windkh/node-red-contrib-shelly#261](https://github.com/windkh/node-red-contrib-shelly/issues/261), where `ble-shelly-blu.js` stopped delivering any BLU event after users updated to `2.0.0`. Reported on a Shelly BLU Gateway Gen3 and a Shelly 1 Mini Gen4, both on `20260710-*/2.0.0-g87fbfa4`, and traced by [@mepetmir](https://github.com/mepetmir).

## Fix

Bail only on an explicit `false`:

```js
//exit only if the BLE is explicitly disabled
if (BLEConfig && BLEConfig.enable === false) {
```

This keeps **both** firmware generations working:

- **< 2.0.0** — `enable` is still a real boolean, so a user who switched Bluetooth off in settings still gets the message and the early return. Behaviour is unchanged.
- **≥ 2.0.0** — the missing flag no longer aborts the script, and scanning auto-activates as the new firmware intends.

The added null check also makes the line safe on a device that reports no `ble` config at all, where the current code throws on `null.enable`.

The change is identical in all fifteen files:

`ble-PTM215B-button` · `ble-aranet2` · `ble-aranet4` · `ble-bparasite` · `ble-miflora-xiaomi-hhccjcy01` · `ble-mopeka` · `ble-pasv-mqtt-gw` · `ble-ruuvi` · `ble-shelly-blu` · `ble-shelly-btn` · `ble-shelly-btn-gateway-for-other-devices` · `ble-shelly-dw` · `ble-shelly-motion` · `ble-shelly-scanner` · `universal-blu-to-mqtt`

## Verification

`ble-shelly-blu.shelly.js` was executed outside the device with stubbed `Shelly` / `BLE` / `console` globals — it has no top-level side effect other than the `init()` call on its last line, so this exercises the device's start-up path directly. Result, before → after:

| `Shelly.getComponentConfig("ble")` | before | after |
| --- | --- | --- |
| `{enable: true, …}` (fw 1.x) | subscribes | subscribes |
| `{rpc: {…}}` (fw 2.0.0+, no `enable`) | **returns early** | subscribes |
| `{enable: false, …}` (BT off) | returns early | returns early |
| `null` | throws | subscribes |

Happy to narrow this to `ble-shelly-blu.shelly.js` alone if you would rather take the other fourteen separately.
