### PR TITLE
Add standard JSDoc metadata header to victron-ble-bridge.shelly.js

### DIFF
--- a/power-energy/victron-ble-bridge.shelly.js
+++ b/power-energy/victron-ble-bridge.shelly.js
@@ -1,4 +1,15 @@
 /**
+ * @title Victron BLE Bridge
+ * @description Acts as a BLE bridge that forwards BLE advertisement data to a
+ *   Victron GX device over HTTPS, so bridged sensors appear under
+ *   Settings -> Bluetooth Sensors just like locally seen ones. Requires Shelly
+ *   firmware 1.5.0+ and GX firmware 3.80+. Configured via Virtual Components
+ *   where supported, otherwise via a venus-host KVS key.
+ * @status production
+ * @link https://github.com/ALLTERCO/shelly-script-examples/blob/main/power-energy/victron-ble-bridge.shelly.js
+ */
+
+/**
  * Victron BLE Bridge
  *
  * Continuously scans BLE advertisements and forwards packets


### PR DESCRIPTION
PR #217 added this script without the @title/@description/@status/@link header that the repo's other scripts carry, so `main` currently fails its own CI gate:

  tools/check-manifest-integrity.py --check-headers --check-sync
  [X] Missing standard JSDoc header
  [X] Non-production file in manifest

Add the standard header block above the existing descriptive comment. No behaviour change; the checks pass again. The existing manifest entry is preserved (post-merge sync only overwrites TODO metadata).